### PR TITLE
Use an AES Cipher to encrypt payloads of any length

### DIFF
--- a/crypto_env_var.gemspec
+++ b/crypto_env_var.gemspec
@@ -32,6 +32,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency 'msgpack', '~> 1.1'
+
   spec.add_development_dependency "bundler", "~> 1.15"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"

--- a/lib/crypto_env_var.rb
+++ b/lib/crypto_env_var.rb
@@ -7,20 +7,14 @@ module CryptoEnvVar
   class << self
     def encrypt(data, private_key_string)
       json = Utils.serialize(data)
-
       cipher = Cipher.new(private_key_string)
-      encrypted_data = cipher.encrypt(json)
-
-      Utils.encode(encrypted_data)
+      cipher.encrypt(json)
     end
 
 
     def decrypt(string, public_key_string)
-      encrypted_data = Utils.decode(string)
-
       cipher = Cipher.new(public_key_string)
-      json = cipher.decrypt(encrypted_data)
-
+      json = cipher.decrypt(string)
       Utils.deserialize(json)
     end
   end

--- a/lib/crypto_env_var.rb
+++ b/lib/crypto_env_var.rb
@@ -8,13 +8,15 @@ module CryptoEnvVar
     def encrypt(data, private_key_string)
       json = Utils.serialize(data)
       cipher = Cipher.new(private_key_string)
-      cipher.encrypt(json)
+      encrypted_data = cipher.encrypt(json)
+      Utils.encode(encrypted_data)
     end
 
 
     def decrypt(string, public_key_string)
+      encrypted_data = Utils.decode(string)
       cipher = Cipher.new(public_key_string)
-      json = cipher.decrypt(string)
+      json = cipher.decrypt(encrypted_data)
       Utils.deserialize(json)
     end
   end

--- a/lib/crypto_env_var/cipher.rb
+++ b/lib/crypto_env_var/cipher.rb
@@ -123,16 +123,6 @@ module CryptoEnvVar
     end
 
 
-    def encode(data)
-      Utils.encode(data)
-    end
-
-
-    def decode(data)
-      Utils.decode(data)
-    end
-
-
     class DigestVerificationError < StandardError
       def message
         "The payload has been tampered with."

--- a/lib/crypto_env_var/cipher.rb
+++ b/lib/crypto_env_var/cipher.rb
@@ -112,7 +112,7 @@ module CryptoEnvVar
 
 
     def sha2_digest(data)
-      OpenSSL::Digest::SHA256.new.digest(data)
+      OpenSSL::Digest::SHA512.new.digest(data)
     end
 
 

--- a/lib/crypto_env_var/cipher.rb
+++ b/lib/crypto_env_var/cipher.rb
@@ -2,16 +2,112 @@ require "openssl"
 
 module CryptoEnvVar
   class Cipher
+    SEPARATOR = "--".freeze
+
     def initialize(key_string)
       @key = OpenSSL::PKey::RSA.new(key_string)
     end
 
+
     def encrypt(plaintext)
+      digest = sha2_digest(plaintext)
+      ciphertext, key, iv = aes_encrypt(plaintext)
+
+      ciphertext = encode(ciphertext)
+      key        = encode(rsa_encrypt(key))
+      iv         = encode(iv)
+      digest     = encode(digest)
+
+      [key, iv, ciphertext, digest].join(SEPARATOR)
+    end
+
+
+    def decrypt(ciphertext)
+      key, iv, ciphertext, digest = ciphertext.split(SEPARATOR)
+
+      ciphertext = decode(ciphertext)
+      key        = rsa_decrypt(decode(key))
+      iv         = decode(iv)
+      digest     = decode(digest)
+      plaintext  = aes_decrypt(ciphertext, key, iv)
+
+      validate_digest!(plaintext, digest)
+
+      plaintext
+    end
+
+
+    private
+
+
+    # Plain RSA private key encryption.
+    # It can only encrypt data smaller than the key size.
+    #
+    def rsa_encrypt(plaintext)
       @key.private_encrypt(plaintext)
     end
 
-    def decrypt(ciphertext)
+
+    # Plain RDS public key decryption.
+    # It can only decrypt data encrypted with the private
+    # key from the keypair.
+    #
+    def rsa_decrypt(ciphertext)
       @key.public_decrypt(ciphertext)
+    end
+
+
+    # AES simmetric encryption.
+    #
+    def aes_encrypt(plaintext)
+      cipher = OpenSSL::Cipher::AES256.new(:CBC)
+      cipher.encrypt
+      key = cipher.random_key
+      iv = cipher.random_iv
+
+      ciphertext = cipher.update(plaintext) + cipher.final
+
+      [ciphertext, key, iv]
+    end
+
+
+    # AES simmetric decryption.
+    #
+    def aes_decrypt(ciphertext, key, iv)
+      cipher = OpenSSL::Cipher::AES256.new(:CBC)
+      cipher.decrypt
+      cipher.key = key
+      cipher.iv = iv
+      
+      cipher.update(ciphertext) + cipher.final
+    end
+
+
+    def sha2_digest(data)
+      OpenSSL::Digest::SHA256.new.digest(data)
+    end
+
+
+    def validate_digest!(plaintext, digest)
+      unless sha2_digest(plaintext) == digest
+        raise DigestVerificationError
+      end
+    end
+
+
+    def encode(data)
+      Utils.encode(data)
+    end
+
+
+    def decode(data)
+      Utils.decode(data)
+    end
+
+    class DigestVerificationError < StandardError
+      def message
+        "Decryption successful, but the message has been tampered with"
+      end
     end
   end
 end

--- a/lib/crypto_env_var/cipher.rb
+++ b/lib/crypto_env_var/cipher.rb
@@ -4,6 +4,7 @@ module CryptoEnvVar
   class Cipher
     SEPARATOR = "--".freeze
     DIGEST_SEPARATOR = "----".freeze
+    VERSION = "v1".freeze # To support multiple versions in the future
 
 
     # Can be initialized with a private or public
@@ -33,7 +34,7 @@ module CryptoEnvVar
       ciphertext = encode(ciphertext)
       key        = encode(rsa_encrypt(key))
       iv         = encode(iv)
-      payload    = [key, iv, ciphertext].join(SEPARATOR)
+      payload    = [VERSION, key, iv, ciphertext].join(SEPARATOR)
       digest     = encode(rsa_encrypt(sha2_digest(payload)))
 
       [payload, digest].join(DIGEST_SEPARATOR)
@@ -54,7 +55,7 @@ module CryptoEnvVar
       digest = rsa_decrypt(decode(digest))
       validate_digest!(payload, digest)
 
-      key, iv, ciphertext = payload.split(SEPARATOR)
+      _version, key, iv, ciphertext = payload.split(SEPARATOR)
 
       ciphertext = decode(ciphertext)
       key        = rsa_decrypt(decode(key))

--- a/spec/crypto_env_var/cipher_spec.rb
+++ b/spec/crypto_env_var/cipher_spec.rb
@@ -54,11 +54,11 @@ RSpec.describe CryptoEnvVar::Cipher do
     end
 
     it "can't decrypt a ciphertext generated with a different private key" do
-      other_private_key = OpenSSL::PKey::RSA.generate(2048)
-      other_cyphertext = other_private_key.private_encrypt(plaintext)
+      other_cipher = described_class.new(OpenSSL::PKey::RSA.generate(2048))
+      other_cyphertext = other_cipher.encrypt(plaintext)
 
       expect(
-        other_private_key.public_decrypt(other_cyphertext)
+        other_cipher.decrypt(other_cyphertext)
       ).to eql plaintext
 
       expect {

--- a/spec/crypto_env_var/cipher_spec.rb
+++ b/spec/crypto_env_var/cipher_spec.rb
@@ -20,6 +20,18 @@ RSpec.describe CryptoEnvVar::Cipher do
       out = subject.decrypt(ciphertext)
       expect(out).to eq plaintext
     end
+
+    describe "with a plaintext larger than the key size" do
+      let(:plaintext) { super() * 20 }
+
+      it "can encrypt and decrypt a text" do
+        ciphertext = subject.encrypt(plaintext)
+        expect(ciphertext).to_not eq plaintext
+
+        out = subject.decrypt(ciphertext)
+        expect(out).to eq plaintext
+      end
+    end
   end
 
 


### PR DESCRIPTION
The simple asymmetric encryption API provided by the RSA keypair class doesn't allow to encrypt data larger than the key size:

```
OpenSSL::PKey::RSAError: data too large for key size
```

There are two common approaches to implement asymmetric encryption for arbitrary size data payloads:

1. Split the plaintext in chunks small enough to be encrypted individually, encrypt them with the private or public key, and join them to have the ciphertext. To decrypt them execute the opposite operation and use the other key. This approach is simple and works but has a number of drawbacks, including being very slow.
2. Use AES to _symmetrically_ encrypt the plaintext, then use the RSA private key to _encrypt the AES key_, and add it to the proper ciphertext to make it part of the secret message. The AES initialization vector needs to be added to the secret message too, as it's necessary for decryption, but it's not sensitive and doesn't need to be encrypted itself. An optional but recommended addition is to calculate a digest of the so composed secret message, encrypt this too with the RSA private key (or it can just be signed), and add this to the secret message as well.
When decrypting, the received secret message is split into its parts and the digest and the AES key are decrypted using the RSA public key.

I've chosen option two.